### PR TITLE
Fix linking issues on NDK r15

### DIFF
--- a/ev.c
+++ b/ev.c
@@ -365,7 +365,7 @@
 # define EV_HEAP_CACHE_AT EV_FEATURE_DATA
 #endif
 
-#ifdef ANDROID
+#ifdef __ANDROID__
 /* supposedly, android doesn't typedef fd_mask */
 # undef EV_USE_SELECT
 # define EV_USE_SELECT 0
@@ -4402,9 +4402,11 @@ inline_size int
 infy_newfd (void)
 {
 #if defined IN_CLOEXEC && defined IN_NONBLOCK
+#if !defined __ANDROID__ || __ANDROID_API__ >= 21
   int fd = inotify_init1 (IN_CLOEXEC | IN_NONBLOCK);
   if (fd >= 0)
     return fd;
+#endif
 #endif
   return inotify_init ();
 }

--- a/ev_epoll.c
+++ b/ev_epoll.c
@@ -240,9 +240,11 @@ int
 epoll_init (EV_P_ int flags)
 {
 #ifdef EPOLL_CLOEXEC
+#if !defined __ANDROID__ || __ANDROID_API__ >= 21
   backend_fd = epoll_create1 (EPOLL_CLOEXEC);
 
   if (backend_fd < 0 && (errno == EINVAL || errno == ENOSYS))
+#endif
 #endif
     backend_fd = epoll_create (256);
 


### PR DESCRIPTION
NDK r15 introduced unified headers which will cause libev failing to link. This commit checks Android API version before attempting to invoke new syscalls.

More information: https://github.com/android-ndk/ndk/issues/394#issuecomment-301710618