### PR TITLE
Fix compilation on platforms other than MinGW

### DIFF
--- a/ev.c
+++ b/ev.c
@@ -1567,7 +1567,11 @@ static EV_ATOMIC_T have_monotonic; /* did clock_gettime (CLOCK_MONOTONIC) work? 
 # define EV_WIN32_HANDLE_TO_FD(handle) (handle)
 #endif
 #ifndef EV_WIN32_CLOSE_FD
+#ifdef _WIN32
 # define EV_WIN32_CLOSE_FD(fd) closesocket (fd)
+#else
+# define EV_WIN32_CLOSE_FD(fd) close (fd)
+#endif
 #endif
 
 #ifdef _WIN32


### PR DESCRIPTION
`closesocket` is only for MinGW while `close` should be used for any other POSIX platforms.